### PR TITLE
Fixation on hashing (btDict : BencodeType)

### DIFF
--- a/src/day02_bencode.md
+++ b/src/day02_bencode.md
@@ -107,7 +107,7 @@ proc hash*(obj: BencodeType): Hash =
     of btDict: 
         var h = 0
         for k, v in obj.d.pairs:
-            h = hash(k) !& hash(v)
+            h = h !& hash(k) !& hash(v)
         !$(h)
 ```
 


### PR DESCRIPTION
A hash value of `btDict` depends on only a final pair of the dictionary, because the `hash` proc overwrite hash on each loop.
Fixed it.